### PR TITLE
use absolute image URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@
 
 A [Sourcegraph](https://sourcegraph.com) extension allowing to find references to a string literal using the Sourcegraph code search.
 
-![example](demo.gif)
+![example](https://github.com/lguychard/sourcegraph-string-references/raw/master/demo.gif


### PR DESCRIPTION
This is currently required for the image to show up at https://sourcegraph.com/extensions/lguychard/string-references.